### PR TITLE
Fixed _setDataPath when the bitcore node is using the regtest network and some bugs related with newer electron versions.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,9 +1,14 @@
 'use strict';
-var app = require('app');  // Module to control application life.
-var BrowserWindow = require('browser-window');  // Module to create native browser window.
+var app = require('electron').app; // Module to control application life.
+var BrowserWindow = require('electron').BrowserWindow; // Module to create native browser window.
 
 // Report crashes to our server.
-require('crash-reporter').start();
+require('electron').crashReporter.start({
+  productName: 'YourName',
+  companyName: 'YourCompany',
+  submitURL: 'https://change-that-to-your-company-domain.com/url-to-submit',
+  autoSubmit: true
+});
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -25,7 +30,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 725, height: 680, resizable: false});
 
   // and load the index.html of the app.
-  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html');
 
   // Open the DevTools.
   //mainWindow.openDevTools();

--- a/stampingservice/index.js
+++ b/stampingservice/index.js
@@ -63,9 +63,9 @@ StampingService.PREFIX = String.fromCharCode(0xff);
 StampingService.prototype._setDataPath = function() {
   $.checkState(this.node.services.bitcoind.spawn.datadir, 'bitcoind is expected to have a "spawn.datadir" property');
   var datadir = this.node.services.bitcoind.spawn.datadir;
-  if (this.node.network === Networks.livenet) {
+  if (this.node.network.name === Networks.livenet.name) {
     this.dataPath = datadir + '/bitcore-stamps.db';
-  } else if (this.node.network === Networks.testnet) {
+  } else if (this.node.network.name === Networks.testnet.name) {
     if (this.node.network.regtestEnabled) {
       this.dataPath = datadir + '/regtest/bitcore-stamps.db';
     } else {


### PR DESCRIPTION
Comparing this.node.network against Networks.livenet and Networks.testnet works when the bitcore node is using the livenet and testnet networks, however when using the regtest network the extra field regTestEnabled present in this.node.network makes comparing it with Networks.testnet to fail.

this.node.network:

Network {
name: 'testnet',
alias: 'regtest',
pubkeyhash: 111,
privatekey: 239,
scripthash: 196,
xpubkey: 70617039,
xprivkey: 70615956,
port: [Getter],
networkMagic: [Getter],
dnsSeeds: [Getter],
regtestEnabled: true }

Networks.testnet:

Network {
name: 'testnet',
alias: 'regtest',
pubkeyhash: 111,
privatekey: 239,
scripthash: 196,
xpubkey: 70617039,
xprivkey: 70615956,
port: [Getter],
networkMagic: [Getter],
dnsSeeds: [Getter] }
